### PR TITLE
Add paid Excel import

### DIFF
--- a/app.py
+++ b/app.py
@@ -96,5 +96,25 @@ def import_excel():
             return redirect(url_for("index"))
     return render_template("import.html")
 
+
+@app.route("/paid", methods=["GET", "POST"])
+def add_paid():
+    if request.method == "POST":
+        file = request.files.get("file")
+        if file:
+            df = pd.read_excel(file, header=None)
+            df = df.iloc[1:, :4]
+            df.columns = ["payment", "claim", "invoice", "amount"]
+            cur = mydb.cursor()
+            for _, row in df.iterrows():
+                cur.execute(
+                    "INSERT INTO paid (payment, claim, invoice, amount) VALUES (%s, %s, %s, %s)",
+                    (row["payment"], row["claim"], row["invoice"], row["amount"]),
+                )
+            mydb.commit()
+            cur.close()
+            return redirect(url_for("index"))
+    return render_template("paid.html")
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
     <div class="container py-4">
         <h1 class="mb-3">ข้อมูล</h1>
         <a href="{{ url_for('import_excel') }}" class="btn btn-success mb-3">นำเข้า Excel</a>
+        <a href="{{ url_for('add_paid') }}" class="btn btn-primary mb-3">นำเข้า Paid</a>
 
         <!-- แถบควบคุมจำนวนต่อหน้า -->
         <form class="row g-2 mb-3" method="get">

--- a/templates/paid.html
+++ b/templates/paid.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="th">
+<head>
+    <meta charset="utf-8">
+    <title>Import Paid Excel</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-4">
+        <h1 class="mb-3">นำเข้า Paid จาก Excel</h1>
+        <form method="post" enctype="multipart/form-data">
+            <div class="mb-3">
+                <label for="file" class="form-label">ไฟล์ Excel Paid</label>
+                <input class="form-control" type="file" id="file" name="file" required>
+            </div>
+            <button type="submit" class="btn btn-primary">นำเข้า</button>
+            <a href="{{ url_for('index') }}" class="btn btn-secondary">กลับ</a>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow uploading an Excel file to import payment, claim, invoice, and amount into the paid table
- add a dedicated page for importing paid records and update navigation link

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6898c2bd59e4832394430277c17d0e26