### PR TITLE
Display imported data on upload pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,8 @@ def index():
 
 @app.route("/import", methods=["GET", "POST"])
 def import_excel():
+    data = None
+    message = None
     if request.method == "POST":
         file = request.files.get("file")
         if file:
@@ -100,15 +102,17 @@ def import_excel():
                 )
             mydb.commit()
             cur.close()
-            return redirect(url_for("index"))
-    return render_template("import.html")
+            data = df.to_dict(orient="records")
+            message = "นำเข้าข้อมูลแล้ว"
+    return render_template("import.html", data=data, message=message)
 
 
 
 @app.route("/paid/import", methods=["GET", "POST"])
 @app.route("/paid/add", methods=["GET", "POST"], endpoint="add_paid")
-
 def import_paid():
+    data = None
+    message = None
     if request.method == "POST":
         file = request.files.get("file")
         if file:
@@ -119,19 +123,18 @@ def import_paid():
             for _, row in df.iterrows():
                 cur.execute(
                     "INSERT INTO paid (payment, claim, invoice, amount) VALUES (%s, %s, %s, %s)",
-
                     (
                         row["payment"],
                         clean_field(row["claim"]),
                         clean_field(row["invoice"]),
                         row["amount"],
                     ),
-
                 )
             mydb.commit()
             cur.close()
-            return redirect(url_for("index"))
-    return render_template("paid.html")
+            data = df.to_dict(orient="records")
+            message = "นำเข้าข้อมูลแล้ว"
+    return render_template("paid.html", data=data, message=message)
 
 
 @app.route("/paid")

--- a/templates/import.html
+++ b/templates/import.html
@@ -16,6 +16,46 @@
             <button type="submit" class="btn btn-primary">นำเข้า</button>
             <a href="{{ url_for('index') }}" class="btn btn-secondary">กลับ</a>
         </form>
+
+        {% if message %}
+        <div class="alert alert-success mt-3" role="alert">{{ message }}</div>
+        {% endif %}
+
+        {% if data %}
+        <div class="table-responsive mt-3">
+            <table class="table table-bordered table-sm">
+                <thead>
+                    <tr>
+                        <th>day</th>
+                        <th>claim</th>
+                        <th>invoice</th>
+                        <th>invoiceref</th>
+                        <th>no</th>
+                        <th>offer</th>
+                        <th>approve</th>
+                        <th>status</th>
+                        <th>statuskey</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in data %}
+                    <tr>
+                        <td>{{ row.day }}</td>
+                        <td>{{ row.claim }}</td>
+                        <td>{{ row.invoice }}</td>
+                        <td>{{ row.invoiceref }}</td>
+                        <td>{{ row.no }}</td>
+                        <td>{{ row.offer }}</td>
+                        <td>{{ row.approve }}</td>
+                        <td>{{ row.status }}</td>
+                        <td>{{ row.statuskey }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
     </div>
 </body>
 </html>

--- a/templates/paid.html
+++ b/templates/paid.html
@@ -16,6 +16,36 @@
             <button type="submit" class="btn btn-primary">นำเข้า</button>
             <a href="{{ url_for('index') }}" class="btn btn-secondary">กลับ</a>
         </form>
+
+        {% if message %}
+        <div class="alert alert-success mt-3" role="alert">{{ message }}</div>
+        {% endif %}
+
+        {% if data %}
+        <div class="table-responsive mt-3">
+            <table class="table table-bordered table-sm">
+                <thead>
+                    <tr>
+                        <th>payment</th>
+                        <th>claim</th>
+                        <th>invoice</th>
+                        <th>amount</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in data %}
+                    <tr>
+                        <td>{{ row.payment }}</td>
+                        <td>{{ row.claim }}</td>
+                        <td>{{ row.invoice }}</td>
+                        <td>{{ row.amount }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Show uploaded isurvey data in a table with success alert on import page
- Show uploaded paid data in a table with success alert on paid import page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68997ed0ec7083239adb3803d05ec26d