### PR TITLE
Sanitize invoice and claim fields during Excel imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,6 +80,10 @@ def import_excel():
                 "statuskey",
             ]
 
+            df["claim"] = df["claim"].apply(clean_field)
+            df["invoice"] = df["invoice"].apply(clean_field)
+            df = df[(df["claim"] != "") & (df["invoice"] != "")]
+
             cur = mydb.cursor()
             for _, row in df.iterrows():
                 cur.execute(
@@ -90,8 +94,8 @@ def import_excel():
                     """,
                     (
                         row["day"],
-                        clean_field(row["claim"]),
-                        clean_field(row["invoice"]),
+                        row["claim"],
+                        row["invoice"],
                         row["invoiceref"],
                         row["no"],
                         row["offer"],
@@ -119,14 +123,17 @@ def import_paid():
             df = pd.read_excel(file, header=None)
             df = df.iloc[1:, :4]
             df.columns = ["payment", "claim", "invoice", "amount"]
+            df["claim"] = df["claim"].apply(clean_field)
+            df["invoice"] = df["invoice"].apply(clean_field)
+            df = df[(df["claim"] != "") & (df["invoice"] != "")]
             cur = mydb.cursor()
             for _, row in df.iterrows():
                 cur.execute(
                     "INSERT INTO paid (payment, claim, invoice, amount) VALUES (%s, %s, %s, %s)",
                     (
                         row["payment"],
-                        clean_field(row["claim"]),
-                        clean_field(row["invoice"]),
+                        row["claim"],
+                        row["invoice"],
                         row["amount"],
                     ),
                 )


### PR DESCRIPTION
## Summary
- Sanitize `claim` and `invoice` columns when importing `isurvey` and `paid` data
- Skip records where cleaned `claim` or `invoice` is blank

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68998115b6508323a71dd52ab707af41