### PR TITLE
Add row numbering and totals to import tables

### DIFF
--- a/templates/import.html
+++ b/templates/import.html
@@ -26,6 +26,7 @@
             <table class="table table-bordered table-sm">
                 <thead>
                     <tr>
+                        <th>#</th>
                         <th>day</th>
                         <th>claim</th>
                         <th>invoice</th>
@@ -40,6 +41,7 @@
                 <tbody>
                     {% for row in data %}
                     <tr>
+                        <td>{{ loop.index }}</td>
                         <td>{{ row.day }}</td>
                         <td>{{ row.claim }}</td>
                         <td>{{ row.invoice }}</td>
@@ -53,6 +55,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            <p class="mt-2">จำนวนทั้งหมด {{ data|length }} รายการ</p>
         </div>
         {% endif %}
 

--- a/templates/paid.html
+++ b/templates/paid.html
@@ -26,6 +26,7 @@
             <table class="table table-bordered table-sm">
                 <thead>
                     <tr>
+                        <th>#</th>
                         <th>payment</th>
                         <th>claim</th>
                         <th>invoice</th>
@@ -35,6 +36,7 @@
                 <tbody>
                     {% for row in data %}
                     <tr>
+                        <td>{{ loop.index }}</td>
                         <td>{{ row.payment }}</td>
                         <td>{{ row.claim }}</td>
                         <td>{{ row.invoice }}</td>
@@ -43,6 +45,7 @@
                     {% endfor %}
                 </tbody>
             </table>
+            <p class="mt-2">จำนวนทั้งหมด {{ data|length }} รายการ</p>
         </div>
         {% endif %}
 


### PR DESCRIPTION
## Summary
- Show sequential numbers for each imported record in tables
- Display total number of imported rows on import and paid pages

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899835d9eb88323891c66ff0db53dd5