### PR TITLE
เพิ่มลำดับและแปลชื่อคอลัมน์ในหน้าหลัก

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -35,20 +35,22 @@
                 <table class="table table-striped table-hover mb-0 align-middle">
                     <thead class="table-dark">
                         <tr>
-                            <th>day</th>
-                            <th>claim</th>
-                            <th>invoice</th>
-                            <th>invoiceref</th>
-                            <th>no</th>
-                            <th>offer</th>
-                            <th>approve</th>
-                            <th>status</th>
-                            <th>statuskey</th>
+                            <th>ลำดับ</th>
+                            <th>วันที่</th>
+                            <th>เลขเคลม</th>
+                            <th>ใบแจ้งหนี้</th>
+                            <th>ใบแจ้งหนี้อ้างอิง</th>
+                            <th>ครั้งที่</th>
+                            <th>เสนอ</th>
+                            <th>อนุมัติ</th>
+                            <th>สถานะตรวจ</th>
+                            <th>สถานะคีย์</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for r in rows %}
                         <tr>
+                            <td>{{ loop.index + (page - 1) * per_page }}</td>
                             <td>{{ r.day }}</td>
                             <td>{{ r.claim }}</td>
                             <td>{{ r.invoice }}</td>


### PR DESCRIPTION
## Summary
- แสดงลำดับข้อมูลแต่ละแถวบนหน้า index
- ปรับชื่อคอลัมน์เป็นภาษาไทยตามที่ต้องการ

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68998dcb75dc83239952893c29c341e3