### PR TITLE
Match invoice references for paid status

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,13 +31,13 @@ def index():
     # ดึงข้อมูลจากตาราง isurvey พร้อมตรวจสอบสถานะจ่าย
     cur.execute(
         """
-        SELECT i.*,
+        SELECT i.*, 
                CASE
                    WHEN EXISTS (
                        SELECT 1
                        FROM paid p
                        WHERE p.claim = i.claim
-                         AND REPLACE(REPLACE(i.invoice, '[', ''), ']', '') = CONCAT('SEABI-', p.invoice)
+                        AND REPLACE(REPLACE(i.invoiceref, '[', ''), ']', '') LIKE CONCAT('%', p.invoice, '%')
                    )
                THEN 'PAID'
                ELSE ''


### PR DESCRIPTION
## Summary
- Determine `PAID` status when an `isurvey.invoiceref` contains the numeric invoice from the `paid` table and claims match

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b1e6abd64832394255b37c0225b80