### PR TITLE
Fix NaN handling in Excel import

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,6 +154,9 @@ def import_excel():
 
                 df["claim"] = df["claim"].apply(clean_field)
                 df["invoice"] = df["invoice"].apply(clean_field)
+                # Replace any NaN values with None so MySQL sees NULL instead of the
+                # literal string "nan", which would cause an "Unknown column" error.
+                df = df.where(pd.notnull(df), None)
                 df = df[(df["claim"] != "") & (df["invoice"] != "")]
                 cur = mydb.cursor()
                 inserted, duplicates = [], 0
@@ -243,6 +246,10 @@ def import_paid():
                 df.columns = ["payment", "claim", "invoice", "amount"]
                 df["claim"] = df["claim"].apply(clean_field)
                 df["invoice"] = df["invoice"].apply(clean_field)
+                # Convert amount to a number and replace NaN with None so the database
+                # gets NULL instead of the string "nan".
+                df["amount"] = pd.to_numeric(df["amount"], errors="coerce")
+                df = df.where(pd.notnull(df), None)
                 df = df[(df["claim"] != "") & (df["invoice"] != "")]
                 cur = mydb.cursor()
                 inserted, duplicates = [], 0


### PR DESCRIPTION
## Summary
- Prevent insertion errors by replacing NaN values with `None` before writing to MySQL.
- Coerce amount column to numeric and ensure NaN values become `NULL` when importing paid data.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6ada2d0348323af9545e053094ec6